### PR TITLE
Correct probe inversion comment

### DIFF
--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -339,7 +339,7 @@ pid_kd: 363.769
 ##	Inductive Probe
 ##	This probe is not used for Z height, only Quad Gantry Leveling
 ##	Z_MAX on mcu_z
-##	If your probe is NO instead of NC, change pin to !^z:P0.10
+##	If your probe is NO instead of NC, change pin to ^!z:P0.10
 pin: ^z:P0.10
 x_offset: 0
 y_offset: 25.0


### PR DESCRIPTION
The comment in the SKR1.4 file uses the incorrect syntax for inverting the probe connection (at least as of current klipper).
The ! and ^ were transposed.